### PR TITLE
Problem: tokenizer doesn't understand 'url', identifiers and public keys

### DIFF
--- a/scratch/brigadier/example_brigadier.sio
+++ b/scratch/brigadier/example_brigadier.sio
@@ -1,0 +1,19 @@
+url pk0   : spub79f708c25a23ed367610facc14035adc7ba4b1bfa9252ef55c6c24f1b9b03aba;
+url top   : "top"::"level";
+url brig  : pk0::top;
+
+url pk1   : spub79f708c25a23ed367610facc14035adc7ba4b1bfa9252ef55c6c24f1b9b03abb;
+url maj1  : "app1";
+url app1  : pk1::maj1;
+
+url pk2   : spub79f708c25a23ed367610facc14035adc7ba4b1bfa9252ef55c6c24f1b9b03abc::"app2";
+url app2  : pk2;
+
+brigadier brig::Brigadier {
+    major {
+        app1::Major1,
+        app2::Major2,
+        spub79f708c25a23ed367610facc14035adc7ba4b1bfa9252ef55c6c24f1b9b03abd::"app3"::Major3,
+        //app1::Commented,
+    }
+}

--- a/sio-frontends/src/brigadier/mod.rs
+++ b/sio-frontends/src/brigadier/mod.rs
@@ -2,7 +2,7 @@ pub mod position;
 pub mod ast;
 
 mod common;
-//mod parser;
+mod parser;
 mod token;
 mod tokenizer;
 //mod stmt_parser;

--- a/sio-frontends/src/brigadier/token.rs
+++ b/sio-frontends/src/brigadier/token.rs
@@ -7,9 +7,16 @@ pub enum Token {
     RightBracket,
     Comma,
     Slash,
-    String(String),
+    Url,
     Semicolon,
+    Colon,
+    ColonColon,
     Import,
+
+    // Literals.
+    Identifier(String),
+    String(String),
+    PublicKey(String),
 
     // Other.
     Eof,
@@ -23,9 +30,16 @@ pub enum TokenKind {
     RightBracket,
     Comma,
     Slash,
-    String,
+    Url,
     Semicolon,
+    Colon,
+    ColonColon,
     Import,
+
+    // Literals.
+    Identifier,
+    String,
+    PublicKey,
 
     // Other.
     Eof,
@@ -54,8 +68,13 @@ impl From<&Token> for TokenKind {
             Token::Comma => TokenKind::Comma,
             Token::Slash => TokenKind::Slash,
             Token::String(_) => TokenKind::String,
+            Token::PublicKey(_) => TokenKind::PublicKey,
+            Token::Url => TokenKind::Url,
             Token::Semicolon => TokenKind::Semicolon,
+            Token::Colon => TokenKind::Colon,
+            Token::ColonColon => TokenKind::ColonColon,
             Token::Import => TokenKind::Import,
+            Token::Identifier(_) => TokenKind::Identifier,
             Token::Eof => TokenKind::Eof,
             Token::UnterminatedString => TokenKind::UnterminatedString,
             Token::Unknown(_) => TokenKind::Unknown,
@@ -71,7 +90,12 @@ impl Display for TokenKind {
             TokenKind::Slash => "'/'",
             TokenKind::Comma => "','",
             TokenKind::Semicolon => "';'",
+            TokenKind::Colon => "':'",
+            TokenKind::ColonColon => "::",
+            TokenKind::Identifier => "identifier",
             TokenKind::String => "string",
+            TokenKind::PublicKey => "public_key",
+            TokenKind::Url => "url",
             TokenKind::Import => "'import'",
             TokenKind::Eof => "<EOF>",
             TokenKind::UnterminatedString => "<Unterminated String>",


### PR DESCRIPTION
Solution: add support of them and an example of what a simple brigadier definition looks like